### PR TITLE
Get lambda names from aws

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -61,6 +61,7 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ inputs.ecr_image_name }}
         FUNCTION_NAMES: ${{ inputs.lambda_names }}
+        PREFIX_FUNCTION_NAMES: ${{ inputs.prefix_function_names }}
         ECR_IMAGE_NAME: ${{ inputs.ecr_image_tag }}
       run: |
         if docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME ; then
@@ -71,7 +72,9 @@ runs:
         fi
 
         if [ -z "${FUNCTION_NAMES}" ]; then
-          FUNCTIONS=$(aws lambda list-functions --query 'Functions[].FunctionName' --output json)
+
+          FUNCTIONS=$(aws lambda list-functions --query "Functions[?starts_with(FunctionName, '${PREFIX_FUNCTION_NAMES}')].FunctionName" --output json)
+          FUNCTIONS=$(aws lambda list-functions --query 'Functions[?starts_with(FunctionName, `${}`)].FunctionName' --output json)
           FUNCTIONS=$(echo $FUNCTIONS | tr -d '[]"')
 
           IFS=',' read -ra FUNCTION_ARRAY <<< "$FUNCTIONS"

--- a/action.yaml
+++ b/action.yaml
@@ -83,5 +83,4 @@ runs:
         for functionName in $FUNCTION_LIST; do
           aws lambda update-function-code --function-name $functionName --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
         done
-
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME"

--- a/action.yaml
+++ b/action.yaml
@@ -74,7 +74,6 @@ runs:
         if [ -z "${FUNCTION_NAMES}" ]; then
 
           FUNCTIONS=$(aws lambda list-functions --query "Functions[?starts_with(FunctionName, '${PREFIX_FUNCTION_NAMES}')].FunctionName" --output json)
-          FUNCTIONS=$(aws lambda list-functions --query 'Functions[?starts_with(FunctionName, `${}`)].FunctionName' --output json)
           FUNCTIONS=$(echo $FUNCTIONS | tr -d '[]"')
 
           IFS=',' read -ra FUNCTION_ARRAY <<< "$FUNCTIONS"

--- a/action.yaml
+++ b/action.yaml
@@ -71,18 +71,17 @@ runs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
         fi
 
+        FUNCTION_LIST=$FUNCTION_NAMES
         if [ -z "${FUNCTION_NAMES}" ]; then
-
           FUNCTIONS=$(aws lambda list-functions --query "Functions[?starts_with(FunctionName, '${PREFIX_FUNCTION_NAMES}')].FunctionName" --output json)
           FUNCTIONS=$(echo $FUNCTIONS | tr -d '[]"')
 
           IFS=',' read -ra FUNCTION_ARRAY <<< "$FUNCTIONS"
-          for functionName in "${FUNCTION_ARRAY[@]}"; do
-            aws lambda update-function-code --function-name $functionName --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
-          done
-        else
-          for functionName in $FUNCTION_NAMES; do
-            aws lambda update-function-code --function-name $functionName --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
-          done
+          FUNCTION_LIST="${FUNCTION_ARRAY[@]}"
         fi
+
+        for functionName in $FUNCTION_LIST; do
+          aws lambda update-function-code --function-name $functionName --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
+        done
+
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME"

--- a/action.yaml
+++ b/action.yaml
@@ -61,6 +61,7 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ inputs.ecr_image_name }}
         FUNCTION_NAMES: ${{ inputs.lambda_names }}
+        FUNCTIONS: ${{ env.FUNCTIONS }}
         ECR_IMAGE_NAME: ${{ inputs.ecr_image_tag }}
       run: |
         if docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME ; then
@@ -70,7 +71,17 @@ runs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
         fi
 
-        for functionName in $FUNCTION_NAMES; do
-          aws lambda update-function-code --function-name $functionName --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
-        done
+        if [ -z "${FUNCTION_NAMES}" ]; then
+          FUNCTIONS=$(aws lambda list-functions --query 'Functions[].FunctionName' --output json)
+          FUNCTIONS=$(echo $FUNCTIONS | tr -d '[]"')
+
+          IFS=',' read -ra FUNCTION_ARRAY <<< "$FUNCTIONS"
+          for functionName in "${FUNCTION_ARRAY[@]}"; do
+            aws lambda update-function-code --function-name $functionName --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
+          done
+        else
+          for functionName in $FUNCTION_NAMES; do
+            aws lambda update-function-code --function-name $functionName --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME
+          done
+        fi
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME"

--- a/action.yaml
+++ b/action.yaml
@@ -61,7 +61,6 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ inputs.ecr_image_name }}
         FUNCTION_NAMES: ${{ inputs.lambda_names }}
-        FUNCTIONS: ${{ env.FUNCTIONS }}
         ECR_IMAGE_NAME: ${{ inputs.ecr_image_tag }}
       run: |
         if docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_NAME ; then


### PR DESCRIPTION
Para STG sería útil que obtenga las lambdas desde AWS. En el caso de prd no es tan útil porque los PR ya están mergeados y además es más seguro directamente seguir utilizando `FUNCTION_NAMES`

Esta modificación permite ejecutar las lambdas creadas sin necesidad de declararlas previamente.
Se agrega `prefix_function_names` que define el prefix de las lambdas (p.e.: `stg-notifications` para el caso de `notification-service`) y se quita `lambda_names`.